### PR TITLE
Update stats text from Partner Companies to 1200+ Recruiters

### DIFF
--- a/client/pages/Index.tsx
+++ b/client/pages/Index.tsx
@@ -1137,7 +1137,7 @@ const Index = () => {
                     1200+
                   </div>
                   <p className="text-gray-600 font-medium text-[10px] md:text-base">
-                    Partner Companies
+                    1200+ Recruiters
                   </p>
                 </div>
                 <div className="text-center p-2 md:p-6 bg-gray-50 rounded-lg md:rounded-xl hover:bg-gray-100 transition-colors duration-300">


### PR DESCRIPTION
## Purpose
The user requested to update the statistics display text in the popup/section from "Partner Companies" to "1200+ Recruiters" to better reflect the actual metric being shown.

## Code changes
- Updated the text content in the Index.tsx component from "Partner Companies" to "1200+ Recruiters"
- Changed the description text while keeping the "1200+" number display intact
- Modified the paragraph element that shows the metric label in the statistics section

tag @builderio-bot for anything you want the bot to do

🔗 [Edit in Builder.io](https://builder.io/app/projects/693a5ffded2447d98232e01bea6a1226/cosmos-verse)

👀 [Preview Link](https://693a5ffded2447d98232e01bea6a1226-cosmos-verse.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>693a5ffded2447d98232e01bea6a1226</projectId>-->
<!--<branchName>cosmos-verse</branchName>-->