### PR TITLE
Update eligibility criteria formatting for BBA, BCA, BTech

### DIFF
--- a/client/pages/Index.tsx
+++ b/client/pages/Index.tsx
@@ -175,7 +175,8 @@ const Index = () => {
           careers: "Banking Officer, Financial Advisor, Insurance Specialist",
         },
       ],
-      eligibility: "Candidates must have secured a minimum of 45% aggregate marks in Class 12th from a recognized board (40% for SC/ST/OBC candidates). No specific subject requirements.",
+      eligibility:
+        "Candidates must have secured a minimum of 45% aggregate marks in Class 12th from a recognized board (40% for SC/ST/OBC candidates). No specific subject requirements.",
     },
     BCA: {
       duration: "3-year program",
@@ -214,7 +215,8 @@ const Index = () => {
             "Full Stack Developer, Web Application Developer, Frontend/Backend Developer",
         },
       ],
-      eligibility: "Candidates must have secured a minimum of 45% aggregate marks in Class 12th from a recognized board (40% for SC/ST/OBC candidates). Mathematics as a compulsory subject is preferred.",
+      eligibility:
+        "Candidates must have secured a minimum of 45% aggregate marks in Class 12th from a recognized board (40% for SC/ST/OBC candidates). Mathematics as a compulsory subject is preferred.",
     },
     MCA: {
       duration: "2-year program",

--- a/client/pages/Index.tsx
+++ b/client/pages/Index.tsx
@@ -175,7 +175,7 @@ const Index = () => {
           careers: "Banking Officer, Financial Advisor, Insurance Specialist",
         },
       ],
-      eligibility: "Candidates must have secured a minimum of 50% aggregate marks in Class 12th from a recognized board (45% for SC/ST/OBC candidates). No specific subject requirements.",
+      eligibility: "Candidates must have secured a minimum of 45% aggregate marks in Class 12th from a recognized board (40% for SC/ST/OBC candidates). No specific subject requirements.",
     },
     BCA: {
       duration: "3-year program",
@@ -214,7 +214,7 @@ const Index = () => {
             "Full Stack Developer, Web Application Developer, Frontend/Backend Developer",
         },
       ],
-      eligibility: "Candidates must have secured a minimum of 50% aggregate marks in Class 12th from a recognized board (45% for SC/ST/OBC candidates). Mathematics as a compulsory subject is preferred.",
+      eligibility: "Candidates must have secured a minimum of 45% aggregate marks in Class 12th from a recognized board (40% for SC/ST/OBC candidates). Mathematics as a compulsory subject is preferred.",
     },
     MCA: {
       duration: "2-year program",
@@ -269,7 +269,7 @@ const Index = () => {
         },
       ],
       eligibility:
-        "Candidates must have secured a minimum of 60% aggregate marks in Class 12th from a recognized board (55% for SC/ST/OBC candidates). Compulsory subjects: Physics, Mathematics and Chemistry with minimum 50% marks in each subject.",
+        "Candidates must have secured a minimum of 45% aggregate marks in Class 12th from a recognized board (40% for SC/ST/OBC candidates). Compulsory subjects: Physics, Mathematics and Chemistry.",
     },
   };
 

--- a/client/pages/Index.tsx
+++ b/client/pages/Index.tsx
@@ -3257,7 +3257,7 @@ const Index = () => {
                 {
                   question: "Why should I choose Sunstone?",
                   answer:
-                    "• Training and development sessions by industry experts\n• Hands-on capstone projects every semester\n�� Professional portfolio development\n• Expert faculty from premier institutions\n• Comprehensive placement support and career guidance\n• Access to pan-India student community",
+                    "• Training and development sessions by industry experts\n• Hands-on capstone projects every semester\n• Professional portfolio development\n• Expert faculty from premier institutions\n• Comprehensive placement support and career guidance\n• Access to pan-India student community",
                   category: "sunstone",
                 },
                 {

--- a/client/pages/Index.tsx
+++ b/client/pages/Index.tsx
@@ -214,7 +214,7 @@ const Index = () => {
             "Full Stack Developer, Web Application Developer, Frontend/Backend Developer",
         },
       ],
-      eligibility: "12th - 45% marks (40% in reserved category).",
+      eligibility: "Candidates must have secured a minimum of 50% aggregate marks in Class 12th from a recognized board (45% for SC/ST/OBC candidates). Mathematics as a compulsory subject is preferred.",
     },
     MCA: {
       duration: "2-year program",

--- a/client/pages/Index.tsx
+++ b/client/pages/Index.tsx
@@ -269,7 +269,7 @@ const Index = () => {
         },
       ],
       eligibility:
-        "12th - 45% (40% in reserved category) Compulsory subjects: Physics, Mathematics and Chemistry.",
+        "Candidates must have secured a minimum of 60% aggregate marks in Class 12th from a recognized board (55% for SC/ST/OBC candidates). Compulsory subjects: Physics, Mathematics and Chemistry with minimum 50% marks in each subject.",
     },
   };
 

--- a/client/pages/Index.tsx
+++ b/client/pages/Index.tsx
@@ -175,7 +175,7 @@ const Index = () => {
           careers: "Banking Officer, Financial Advisor, Insurance Specialist",
         },
       ],
-      eligibility: "12th - 45% marks (40% in reserved category).",
+      eligibility: "Candidates must have secured a minimum of 50% aggregate marks in Class 12th from a recognized board (45% for SC/ST/OBC candidates). No specific subject requirements.",
     },
     BCA: {
       duration: "3-year program",


### PR DESCRIPTION
## Purpose
The user requested to improve the formatting and formality of eligibility criteria for BBA, BCA, and BTech programs. They wanted to standardize the eligibility requirements to clearly state the 45% marks requirement for general category and 40% for reserved categories, while properly mentioning compulsory subjects without percentage requirements for specific subjects.

## Code changes
- **BBA eligibility**: Updated from brief format to formal description stating "minimum of 45% aggregate marks in Class 12th from a recognized board (40% for SC/ST/OBC candidates)" with no specific subject requirements
- **BCA eligibility**: Enhanced formatting with same formal structure and added note that "Mathematics as a compulsory subject is preferred"
- **BTech eligibility**: Standardized format while maintaining compulsory subjects requirement (Physics, Mathematics and Chemistry)
- **Minor fix**: Removed corrupted character in FAQ section for "Why should I choose Sunstone?" answer

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 18`

🔗 [Edit in Builder.io](https://builder.io/app/projects/16f3550f16724c129f34c88d7121993d/vibe-verse)

👀 [Preview Link](https://16f3550f16724c129f34c88d7121993d-vibe-verse.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>16f3550f16724c129f34c88d7121993d</projectId>-->
<!--<branchName>vibe-verse</branchName>-->