### PR TITLE
Increase scholarship popup width for desktop view

### DIFF
--- a/client/pages/Index.tsx
+++ b/client/pages/Index.tsx
@@ -1270,7 +1270,7 @@ const Index = () => {
       {showScholarshipPopup && (
         <div className="fixed inset-0 bg-black/70 backdrop-blur-sm z-50 flex items-end justify-center md:items-center md:justify-center">
           <div
-            className={`bg-white rounded-t-2xl md:rounded-2xl w-full max-w-sm md:max-w-lg md:w-full relative shadow-2xl max-h-[75vh] md:max-h-[90vh] overflow-y-auto transform transition-all duration-300 ease-out ${showScholarshipPopup ? "translate-y-0" : "translate-y-full"}`}
+            className={`bg-white rounded-t-2xl md:rounded-2xl w-full max-w-sm md:max-w-2xl md:w-full relative shadow-2xl max-h-[75vh] md:max-h-[90vh] overflow-y-auto transform transition-all duration-300 ease-out ${showScholarshipPopup ? "translate-y-0" : "translate-y-full"}`}
           >
             <button
               onClick={() => setShowScholarshipPopup(false)}


### PR DESCRIPTION
## Purpose
The user requested to make the scholarship option popup wider for desktop view to improve the user experience and provide more space for content display.

## Code changes
- Updated the scholarship popup's maximum width class from `md:max-w-lg` to `md:max-w-2xl` in the Index.tsx component
- This change only affects desktop view (medium breakpoint and above) while maintaining the existing mobile layout

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 20`

🔗 [Edit in Builder.io](https://builder.io/app/projects/aa8e978a2aab4577ad88285fae80123c/pixel-verse)

👀 [Preview Link](https://aa8e978a2aab4577ad88285fae80123c-pixel-verse.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>aa8e978a2aab4577ad88285fae80123c</projectId>-->
<!--<branchName>pixel-verse</branchName>-->