### PR TITLE
Fix mobile responsiveness and remove emoji from headings

### DIFF
--- a/client/pages/Index.tsx
+++ b/client/pages/Index.tsx
@@ -862,7 +862,7 @@ const Index = () => {
                     {/* Interactive CTA Buttons */}
                     <div className="flex flex-col sm:flex-row gap-3">
                       <a
-                        href="https://sunstone.in/all-campuses-program"
+                        href="https://sunstone.in/campuses/hi-tech-institute"
                         target="_blank"
                         rel="noopener noreferrer"
                         className="px-6 py-3 bg-[#c38935] hover:bg-[#d4a853] text-white font-bold rounded-xl transition-all duration-300 transform hover:scale-105 hover:shadow-xl flex items-center justify-center group/btn"
@@ -2931,29 +2931,29 @@ const Index = () => {
 
           {/* CTA Section */}
           <div className="text-center">
-            <div className="bg-gradient-to-r from-[#22336a] to-[#c38935] rounded-2xl p-8 md:p-12 text-white">
-              <h3 className="text-2xl md:text-4xl font-bold mb-4">
+            <div className="bg-gradient-to-r from-[#22336a] to-[#c38935] rounded-2xl p-4 md:p-12 text-white">
+              <h3 className="text-lg md:text-4xl font-bold mb-3 md:mb-4">
                 Ready to Begin Your Journey?
               </h3>
-              <p className="text-lg mb-8 opacity-90 max-w-2xl mx-auto">
+              <p className="text-sm md:text-lg mb-4 md:mb-8 opacity-90 max-w-2xl mx-auto">
                 Join thousands of successful graduates at top companies
                 worldwide. Your success story starts with a single step.
               </p>
-              <div className="flex flex-col sm:flex-row gap-4 justify-center items-center">
+              <div className="flex flex-col sm:flex-row gap-3 md:gap-4 justify-center items-center">
                 <a
                   href="tel:+917065303030"
-                  className="inline-flex items-center px-8 py-4 bg-white text-[#22336a] font-bold rounded-xl hover:shadow-xl transition-all duration-300 transform hover:scale-105"
+                  className="inline-flex items-center px-4 py-2 md:px-8 md:py-4 bg-white text-[#22336a] font-bold text-sm md:text-base rounded-xl hover:shadow-xl transition-all duration-300 transform hover:scale-105"
                 >
-                  <Phone className="h-5 w-5 mr-3" />
+                  <Phone className="h-4 w-4 md:h-5 md:w-5 mr-2 md:mr-3" />
                   Call Us Now
                 </a>
                 <a
                   href="https://sunstone.in/apply-now"
                   target="_blank"
                   rel="noopener noreferrer"
-                  className="inline-flex items-center px-8 py-4 bg-transparent border-2 border-white text-white font-bold rounded-xl hover:bg-white hover:text-[#22336a] transition-all duration-300 transform hover:scale-105"
+                  className="inline-flex items-center px-4 py-2 md:px-8 md:py-4 bg-transparent border-2 border-white text-white font-bold text-sm md:text-base rounded-xl hover:bg-white hover:text-[#22336a] transition-all duration-300 transform hover:scale-105"
                 >
-                  <ExternalLink className="h-5 w-5 mr-3" />
+                  <ExternalLink className="h-4 w-4 md:h-5 md:w-5 mr-2 md:mr-3" />
                   Apply Now
                 </a>
               </div>


### PR DESCRIPTION
## Purpose
The user requested several mobile responsiveness improvements and UI fixes across the admission process section. The main goals were to:
- Remove emoji from video heading for cleaner appearance
- Fix content overflow issues in admission process containers
- Improve mobile view sizing and readability
- Ensure consistent container sizing
- Update redirect link for campus tour button

## Code changes
- **Mobile text sizing**: Added responsive text classes (`text-xs sm:text-sm md:text-base`) to hero banner and admission process sections for better mobile readability
- **ROI bubble visibility**: Increased size of 63% ROI indicator from `w-5 h-5` to `w-8 h-8` on mobile to improve visibility
- **Emoji removal**: Removed ✨ emoji from "Hi-Tech Institute - Where Dreams Become Reality" heading
- **Container sizing**: Standardized admission process containers with increased height (`h-[280px] md:h-[300px]`) and adjusted grid layout for mobile
- **Link update**: Changed campus tour redirect from generic all-campuses page to specific Hi-Tech Institute page
- **CTA section**: Improved mobile spacing and button sizing in the call-to-action section with responsive padding and text sizes

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 35`

🔗 [Edit in Builder.io](https://builder.io/app/projects/fe4185efde60421dbb209f1874b85941/mystic-garden)

👀 [Preview Link](https://fe4185efde60421dbb209f1874b85941-mystic-garden.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>fe4185efde60421dbb209f1874b85941</projectId>-->
<!--<branchName>mystic-garden</branchName>-->