### PR TITLE
Simplify hero banner carousel to HTML-style implementation

### DIFF
--- a/client/pages/Index.tsx
+++ b/client/pages/Index.tsx
@@ -436,13 +436,16 @@ const Index = () => {
               <div className="relative max-w-xs md:max-w-xl mx-auto">
                 <div className="relative bg-white rounded-lg md:rounded-xl p-2 md:p-2 shadow-lg">
                   {/* HTML-style Carousel Container */}
-                  <div className="relative rounded-lg md:rounded-xl overflow-hidden" style={{ aspectRatio: '4/3' }}>
+                  <div
+                    className="relative rounded-lg md:rounded-xl overflow-hidden"
+                    style={{ aspectRatio: "4/3" }}
+                  >
                     {/* Carousel Slides - Opacity based transitions */}
                     {carouselImages.map((item, index) => (
                       <div
                         key={index}
                         className={`absolute top-0 left-0 w-full h-full transition-opacity duration-500 ease-in-out ${
-                          index === currentSlide ? 'opacity-100' : 'opacity-0'
+                          index === currentSlide ? "opacity-100" : "opacity-0"
                         }`}
                       >
                         {item.type === "video" ? (
@@ -472,8 +475,8 @@ const Index = () => {
                           onClick={() => setCurrentSlide(index)}
                           className={`w-2 h-2 rounded-full cursor-pointer transition-all duration-300 ${
                             index === currentSlide
-                              ? 'bg-white'
-                              : 'bg-white/50 hover:bg-white/70'
+                              ? "bg-white"
+                              : "bg-white/50 hover:bg-white/70"
                           }`}
                         />
                       ))}


### PR DESCRIPTION
## Purpose
The user requested to add a carousel in the hero banner of the hitech-institute-website.html with multiple images and one video. The goal was to implement a carousel container that supports both image and video content in the hero section.

## Code changes
- **Simplified carousel implementation**: Replaced complex slide-based carousel with HTML-style opacity transitions
- **Removed navigation arrows**: Eliminated left/right arrow buttons for cleaner interface
- **Streamlined video handling**: Removed complex video mute controls and overlay elements
- **Simplified styling**: Removed caption overlay and complex background elements
- **Updated transitions**: Changed from transform-based sliding to opacity-based fade transitions
- **Maintained dot navigation**: Kept bottom dot indicators for slide selection
- **Fixed aspect ratio**: Set consistent 4:3 aspect ratio for all carousel content

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 39`

🔗 [Edit in Builder.io](https://builder.io/app/projects/d405ca24f58e4e07a06546432be9e410/aura-sanctuary)

👀 [Preview Link](https://d405ca24f58e4e07a06546432be9e410-aura-sanctuary.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>d405ca24f58e4e07a06546432be9e410</projectId>-->
<!--<branchName>aura-sanctuary</branchName>-->